### PR TITLE
Added local storage json results support.

### DIFF
--- a/packages/system_monitor/__main__.py
+++ b/packages/system_monitor/__main__.py
@@ -13,6 +13,7 @@ def main():
         print('{} version {}\n'.format(APP_NAME, __version__))
         exit(0)
     # ---
+    
     # parse arguments
     parsed = parser.parse_args()
     # create app and spin it

--- a/packages/system_monitor/app.py
+++ b/packages/system_monitor/app.py
@@ -40,9 +40,6 @@ class SystemMonitor(DTProcess):
     def __init__(self, args):
         super(SystemMonitor, self).__init__(APP_NAME)
         self.args = args
-        print("ARGS:")
-        print(self.args)
-        print("===================")
         self._start_time = time.time()
         self._start_time_iso = _iso_now()
         self._lock = threading.Semaphore(1)

--- a/packages/system_monitor/cli.py
+++ b/packages/system_monitor/cli.py
@@ -60,11 +60,14 @@ def get_parser():
                         default='(empty)',
                         type=str,
                         help="Custom notes to attach to the log")
-    parser.add_argument('--debug', action='store_true', default=False, help="Run in debug mode")
+    parser.add_argument('--debug', action='store_true',
+                        default=False, help="Run in debug mode")
     parser.add_argument('-vv',
                         '--verbose',
                         dest='verbose',
                         action='store_true',
                         default=False,
                         help="Run in verbose mode")
+    parser.add_argument("--no-upload", dest="no_upload", action="store_true",
+                        default=False, help="Do not upload the statistics to the Duckietown server.")
     return parser


### PR DESCRIPTION
The `dts diagnostic` command accepts `--no-upload` flag that stores the results of the diagnostics of the running Docker containers under the `/tmp` folder.
This pull request is related to the [pull request 320](https://github.com/duckietown/duckietown-shell-commands/pull/320) in the duckietown-shell-commands.